### PR TITLE
docs: update README to reflect no npm publish yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,13 @@ npm install -g .
 
 This makes `beadboard` and `bd` commands available globally.
 
+**Alternative: Platform-specific wrappers**
+
+If you prefer not to install globally via npm, you can use the platform-specific wrappers.
+
+POSIX (Linux/macOS):
+```bash
+bash ./install/install.sh
 ### Development Setup
 
 ```bash


### PR DESCRIPTION
## Summary

- Remove npm version badge since BeadBoard is not published to npm yet
- Update installation instructions from `npm install -g beadboard` to clone + `npm install -g .`
- Add explicit note that BeadBoard may be published in the future if there's demand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation to emphasize clone-from-source workflow and local global install.
  * Clarified BeadBoard is not published to npm and added a prominent note about installing from source.
  * Removed npm badges from the README header and streamlined installation/development sections.
  * Removed Windows-specific wrapper guidance; retained POSIX install instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->